### PR TITLE
small fix for email threads

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -10,19 +10,18 @@ pub(crate) fn send(
 ) -> Result<(), lettre::sendmail::error::Error> {
     let mut mailer = SendmailTransport::new();
 
-    for recipient in recipients {
-        let email = Email::builder()
+    let mut builder = Email::builder()
             .from(sender.clone())
-            .to(recipient)
             .subject(subject.clone())
-            .text(text.clone())
-            .build();
-        match email {
-            Ok(email) => mailer.send(email.into())?,
-            Err(e) => {
-                println!("couldn't construct email: {}", e);
-                continue;
-            }
+            .text(text.clone());
+    for recipient in recipients {
+        builder = builder.to(recipient);
+    }
+    let email = builder.build();
+    match result {
+        Ok(result) => mailer.send(result.into())?,
+        Err(e) => {
+            println!("couldn't construct email: {}", e);
         }
     }
 


### PR DESCRIPTION
Make it so that the same email is sent to all staff on submission rather than different instances of the same email.

This fix makes it so that email threads appear consistent for all staff, and that all staff are on the reply to list.